### PR TITLE
Certspotter error fixed

### DIFF
--- a/lazyrecon.sh
+++ b/lazyrecon.sh
@@ -113,7 +113,8 @@ recon(){
   echo "Listing subdomains using sublister..."
   python ~/tools/Sublist3r/sublist3r.py -d $domain -t 10 -v -o ./$domain/$foldername/$domain.txt > /dev/null
   echo "Checking certspotter..."
-  curl -s https://certspotter.com/api/v0/certs\?domain\=$domain | jq '.[].dns_names[]' | sed 's/\"//g' | sed 's/\*\.//g' | sort -u | grep $domain >> ./$domain/$foldername/$domain.txt
+   # certspotter api v1 curl req added
+  curl -s https://api.certspotter.com/v1/issuances\?domain=$domain\&expand=dns_names\&expand=issuer\&expand=cert | jq '.[].dns_names[]' | sed 's/\"//g' | sed 's/\*\.//g' | sort -u | grep $domain >> ./$domain/$foldername/$domain.txt
   nsrecords $domain
   excludedomains
   echo "Starting discovery..."


### PR DESCRIPTION
Updated Certspotter API v1 and fixed jq: error (at <stdin>:0): Cannot index string with string "dns_names"